### PR TITLE
Split the import process into plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ Please join the #feature-publications-importer channel on LGD Slack to learn mor
 Don't install this in your production site yet.
 
 You can fund the development of this feature via the [LocalGov Drupal Community Fund](https://localgovdrupal.org/products/community-fund/pdf-import-discovery).
+
+
+Plugin structure:
+
+We work on an Import. This has an ImportInterface.
+
+Operations are what happens to an Import. These can be one of three types:
+  Extract: Plugin/LocalGovImporter/Extract
+  Transform: Plugin/LocalGovImporter/Transform
+  Save: Plugin/LocalGovImporter/Save

--- a/README.md
+++ b/README.md
@@ -9,26 +9,35 @@ Don't install this in your production site yet.
 
 You can fund the development of this feature via the [LocalGov Drupal Community Fund](https://localgovdrupal.org/products/community-fund/pdf-import-discovery).
 
+## How to try this out
 
-## Architecture
-We work on an Import. This is a class that implements ImportInterface. It has a
-number of Pages, which implement PageInterface. Extracted content is put in 
-Pages in an Import, and passed to the other plugins via the importer to complete
-the import process.
+1) Enable the module.
+2) Choose "Content" -> "Import Publication" from the admin menu.
+3) Upload a PDF file to the form and submit it.
+4) After a few seconds, you'll get redirected to a new HTML Publication created from the supplied PDF.
+
+If you'd like to use AI to clean up the text, you can. The default AI chat
+provider will be used if one is configured. To configure one using ChatGPT,
+you'll need to get an API key from OpenAI, then:
+
+1) Choose "Configuration" -> "AI" -> "Provider Settings" -> "OpenAI Authentication" from the admin menu.
+2) Click the link saying "create a new key".
+3) Add your API key here. Key name and description can be whatever makes sense to you. Key type should be "Authentication". Key provider can be "Configuration" if you're just testing locally. Value is the key itself.
+4) Save the key and head to "Configuration" -> "AI" -> "Provider Settings" -> "OpenAI Authentication" again.
+5) This time you can choose your key from the dropdown. The key will be verified on save, so if you put in a key that's incorrect, you'll be notified here.
+6) Once the key is saved, head to "Configuration" -> "AI" -> "AI Default Settings".
+7) Scroll down to chat. Ensure OpenAI is selected. Choose the model you'd like to use. GPT-4o seems to work.
+
+Now repeat the steps to upload a PDF from before. You'll notice that the form submission takes longer, and the results are cleaned up compared to what they were previously like.
+
+
+
+
+Plugin structure:
+
+We work on an Import. This has an ImportInterface.
 
 Operations are what happens to an Import. These can be one of three types:
   Extract: Plugin/LocalGovImporter/Extract
   Transform: Plugin/LocalGovImporter/Transform
   Save: Plugin/LocalGovImporter/Save
-
-The process must include one extract operation and one save operation. Transform
-operations are optional, and there can be any number of them.
-
-As each operation is implemented in plugins, you can customise the import 
-process to meet your requirements.
-
-## Maintainers
-
-This project is currently maintained by:
-
-- Rupert Jabelman: https://www.drupal.org/u/rupertj

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ you'll need to get an API key from OpenAI, then:
 
 Now repeat the steps to upload a PDF from before. You'll notice that the form submission takes longer, and the results are cleaned up compared to what they were previously like.
 
+## Plugin structure:
 
+This module is designed to be customisable. You can either write your own plugins to affect how content is imported, or use Drupal modules that provide plugins.
 
-
-Plugin structure:
-
-We work on an Import. This has an ImportInterface.
+We work on an instance of ImportInterface, which is passed between plugins. There's a default implementation called Import, but you can use your own if you like.
 
 Operations are what happens to an Import. These can be one of three types:
-  Extract: Plugin/LocalGovImporter/Extract
-  Transform: Plugin/LocalGovImporter/Transform
-  Save: Plugin/LocalGovImporter/Save
+* Extract: Plugin/LocalGovImporter/Extract
+* Transform: Plugin/LocalGovImporter/Transform
+* Save: Plugin/LocalGovImporter/Save
+
+Content is extracted from the uploaded file by an Extract plugin, and placed on an Import object. It's then transformed by any number of Transform plugins, and saved by a Save plugin.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,25 @@ Don't install this in your production site yet.
 You can fund the development of this feature via the [LocalGov Drupal Community Fund](https://localgovdrupal.org/products/community-fund/pdf-import-discovery).
 
 
-Plugin structure:
-
-We work on an Import. This has an ImportInterface.
+## Architecture
+We work on an Import. This is a class that implements ImportInterface. It has a
+number of Pages, which implement PageInterface. Extracted content is put in 
+Pages in an Import, and passed to the other plugins via the importer to complete
+the import process.
 
 Operations are what happens to an Import. These can be one of three types:
   Extract: Plugin/LocalGovImporter/Extract
   Transform: Plugin/LocalGovImporter/Transform
   Save: Plugin/LocalGovImporter/Save
+
+The process must include one extract operation and one save operation. Transform
+operations are optional, and there can be any number of them.
+
+As each operation is implemented in plugins, you can customise the import 
+process to meet your requirements.
+
+## Maintainers
+
+This project is currently maintained by:
+
+- Rupert Jabelman: https://www.drupal.org/u/rupertj

--- a/localgov_publications_importer.info.yml
+++ b/localgov_publications_importer.info.yml
@@ -5,5 +5,6 @@ package: LocalGov Drupal
 core_version_requirement: ^9 || ^10
 
 dependencies:
+  - paragraphs:paragraphs
   - localgov_publications:localgov_publications
   - ai_provider_openai:ai_provider_openai

--- a/localgov_publications_importer.services.yml
+++ b/localgov_publications_importer.services.yml
@@ -1,4 +1,8 @@
 services:
   localgov_publications_importer.importer:
     class: Drupal\localgov_publications_importer\Service\Importer
-    arguments: ['@entity_type.manager','@ai.provider']
+    arguments: ['@entity_type.manager','@ai.provider', 'Drupal\localgov_publications_importer\ExtractOperationManager']
+  plugin.manager.localgov_importer.extract:
+    class: Drupal\localgov_publications_importer\ExtractOperationManager
+    parent: default_plugin_manager
+  Drupal\localgov_publications_importer\ExtractOperationManager: '@plugin.manager.localgov_importer.extract'

--- a/localgov_publications_importer.services.yml
+++ b/localgov_publications_importer.services.yml
@@ -6,3 +6,7 @@ services:
     class: Drupal\localgov_publications_importer\ExtractOperationManager
     parent: default_plugin_manager
   Drupal\localgov_publications_importer\ExtractOperationManager: '@plugin.manager.localgov_importer.extract'
+  plugin.manager.localgov_importer.save:
+    class: Drupal\localgov_publications_importer\SaveOperationManager
+    parent: default_plugin_manager
+  Drupal\localgov_publications_importer\SaveOperationManager: '@plugin.manager.localgov_importer.save'

--- a/localgov_publications_importer.services.yml
+++ b/localgov_publications_importer.services.yml
@@ -1,11 +1,15 @@
 services:
   localgov_publications_importer.importer:
     class: Drupal\localgov_publications_importer\Service\Importer
-    arguments: ['@entity_type.manager','@ai.provider', 'Drupal\localgov_publications_importer\ExtractOperationManager']
+    arguments: ['Drupal\localgov_publications_importer\ExtractOperationManager', 'Drupal\localgov_publications_importer\TransformOperationManager', 'Drupal\localgov_publications_importer\SaveOperationManager']
   plugin.manager.localgov_importer.extract:
     class: Drupal\localgov_publications_importer\ExtractOperationManager
     parent: default_plugin_manager
   Drupal\localgov_publications_importer\ExtractOperationManager: '@plugin.manager.localgov_importer.extract'
+  plugin.manager.localgov_importer.transform:
+    class: Drupal\localgov_publications_importer\TransformOperationManager
+    parent: default_plugin_manager
+  Drupal\localgov_publications_importer\TransformOperationManager: '@plugin.manager.localgov_importer.transform'
   plugin.manager.localgov_importer.save:
     class: Drupal\localgov_publications_importer\SaveOperationManager
     parent: default_plugin_manager

--- a/localgov_publications_importer.services.yml
+++ b/localgov_publications_importer.services.yml
@@ -1,7 +1,7 @@
 services:
   localgov_publications_importer.importer:
     class: Drupal\localgov_publications_importer\Service\Importer
-    arguments: ['Drupal\localgov_publications_importer\ExtractOperationManager', 'Drupal\localgov_publications_importer\TransformOperationManager', 'Drupal\localgov_publications_importer\SaveOperationManager']
+    arguments: ['@Drupal\localgov_publications_importer\ExtractOperationManager', '@Drupal\localgov_publications_importer\TransformOperationManager', '@Drupal\localgov_publications_importer\SaveOperationManager']
   plugin.manager.localgov_importer.extract:
     class: Drupal\localgov_publications_importer\ExtractOperationManager
     parent: default_plugin_manager

--- a/src/Attribute/Extract.php
+++ b/src/Attribute/Extract.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines an Extract attribute object.
+ */
+#[\Attribute(
+  \Attribute::TARGET_CLASS,
+)]
+class Extract extends Plugin {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup $description,
+  ) {
+  }
+
+}

--- a/src/Attribute/Save.php
+++ b/src/Attribute/Save.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a Save attribute object.
+ */
+#[\Attribute(
+  \Attribute::TARGET_CLASS,
+)]
+class Save extends Plugin {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup $description,
+  ) {
+  }
+
+}

--- a/src/Attribute/Transform.php
+++ b/src/Attribute/Transform.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a Transform attribute object.
+ */
+#[\Attribute(
+  \Attribute::TARGET_CLASS,
+)]
+class Transform extends Plugin {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup $description,
+  ) {
+  }
+
+}

--- a/src/ExtractOperationManager.php
+++ b/src/ExtractOperationManager.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\localgov_publications_importer\Attribute\Extract;
+use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
+
+/**
+ * Manages discovery and instantiation of Extract operations.
+ */
+class ExtractOperationManager extends DefaultPluginManager {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/LocalGovImporter/Extract',
+      $namespaces,
+      $module_handler,
+      ExtractInterface::class,
+      Extract::class
+    );
+
+    $this->alterInfo('localgov_importer_extract_operation_info');
+    $this->setCacheBackend($cache_backend, 'localgov_importer_extract_operations');
+  }
+
+//  /**
+//   * {@inheritdoc}
+//   */
+//  protected function getType() {
+//    return 'extract_operation';
+//  }
+
+}

--- a/src/ExtractOperationManager.php
+++ b/src/ExtractOperationManager.php
@@ -33,11 +33,4 @@ class ExtractOperationManager extends DefaultPluginManager {
     $this->setCacheBackend($cache_backend, 'localgov_importer_extract_operations');
   }
 
-//  /**
-//   * {@inheritdoc}
-//   */
-//  protected function getType() {
-//    return 'extract_operation';
-//  }
-
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -27,7 +27,7 @@ class Import {
     $this->pathToFile = $pathToFile;
   }
 
-  public function setTitle(string $title) {
+  public function setTitle(string $title): void {
     $this->title = $title;
   }
 
@@ -35,7 +35,7 @@ class Import {
     return $this->title;
   }
 
-  public function setPages(array $pages) {
+  public function setPages(array $pages): void {
     $this->pages = $pages;
   }
 

--- a/src/Import.php
+++ b/src/Import.php
@@ -23,7 +23,7 @@ class Import {
 
   /**
    * Array of pages.
-   * 
+   *
    * @var array
    */
   protected array $pages = [];

--- a/src/Import.php
+++ b/src/Import.php
@@ -5,7 +5,7 @@ namespace Drupal\localgov_publications_importer;
 /**
  * Represents content being imported.
  */
-class Import {
+class Import implements ImportInterface {
 
   /**
    * Path to the original file.
@@ -24,7 +24,7 @@ class Import {
   /**
    * Array of pages.
    *
-   * @var Page[]
+   * @var \Drupal\localgov_publications_importer\PageInterface[]
    */
   protected array $pages = [];
 
@@ -36,40 +36,37 @@ class Import {
   }
 
   /**
-   * Set the title of the import.
+   * {@inheritdoc}
    */
   public function setTitle(string $title): void {
     $this->title = $title;
   }
 
   /**
-   * Get the title of the import.
+   * {@inheritdoc}
    */
   public function getTitle(): string {
     return $this->title;
   }
 
   /**
-   * Set the pages of the import.
-   *
-   * @param Page[] $pages
-   *   Array of pages.
+   * {@inheritdoc}
    */
   public function setPages(array $pages): void {
     $this->pages = $pages;
   }
 
   /**
-   * Get the pages of the import.
+   * {@inheritdoc}
    */
   public function getPages(): array {
     return $this->pages;
   }
 
   /**
-   * Add a new page to this import.
+   * {@inheritdoc}
    */
-  public function addPage(Page $page): void {
+  public function addPage(PageInterface $page): void {
     $this->pages[] = $page;
   }
 

--- a/src/Import.php
+++ b/src/Import.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+/**
+ * Represents content being imported.
+ */
+class Import {
+
+  /**
+   * Path to the original file.
+   *
+   * @var string
+   */
+  protected string $pathToFile;
+
+  /**
+   * Title of the document.
+   *
+   * @var string
+   */
+  protected string $title = '';
+
+  protected array $pages = [];
+
+  public function __construct(string $pathToFile) {
+    $this->pathToFile = $pathToFile;
+  }
+
+  public function setTitle(string $title) {
+    $this->title = $title;
+  }
+
+  public function getTitle(): string {
+    return $this->title;
+  }
+
+  public function setPages(array $pages) {
+    $this->pages = $pages;
+  }
+
+  public function getPages(): array {
+    return $this->pages;
+  }
+
+}

--- a/src/Import.php
+++ b/src/Import.php
@@ -24,7 +24,7 @@ class Import {
   /**
    * Array of pages.
    *
-   * @var array
+   * @var Page[]
    */
   protected array $pages = [];
 
@@ -51,6 +51,9 @@ class Import {
 
   /**
    * Set the pages of the import.
+   *
+   * @param Page[] $pages
+   *   Array of pages.
    */
   public function setPages(array $pages): void {
     $this->pages = $pages;
@@ -61,6 +64,13 @@ class Import {
    */
   public function getPages(): array {
     return $this->pages;
+  }
+
+  /**
+   * Add a new page to this import.
+   */
+  public function addPage(Page $page): void {
+    $this->pages[] = $page;
   }
 
 }

--- a/src/Import.php
+++ b/src/Import.php
@@ -21,24 +21,44 @@ class Import {
    */
   protected string $title = '';
 
+  /**
+   * Array of pages.
+   * 
+   * @var array
+   */
   protected array $pages = [];
 
+  /**
+   * Constructor.
+   */
   public function __construct(string $pathToFile) {
     $this->pathToFile = $pathToFile;
   }
 
+  /**
+   * Set the title of the import.
+   */
   public function setTitle(string $title): void {
     $this->title = $title;
   }
 
+  /**
+   * Get the title of the import.
+   */
   public function getTitle(): string {
     return $this->title;
   }
 
+  /**
+   * Set the pages of the import.
+   */
   public function setPages(array $pages): void {
     $this->pages = $pages;
   }
 
+  /**
+   * Get the pages of the import.
+   */
   public function getPages(): array {
     return $this->pages;
   }

--- a/src/ImportInterface.php
+++ b/src/ImportInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+/**
+ * Interface for content being imported.
+ */
+interface ImportInterface {
+
+  /**
+   * Set the title of the import.
+   */
+  public function setTitle(string $title): void;
+
+  /**
+   * Get the title of the import.
+   */
+  public function getTitle(): string;
+
+  /**
+   * Set the pages of the import.
+   *
+   * @param \Drupal\localgov_publications_importer\PageInterface[] $pages
+   *   Array of pages.
+   */
+  public function setPages(array $pages): void;
+
+  /**
+   * Get the pages of the import.
+   *
+   * @return \Drupal\localgov_publications_importer\PageInterface[]
+   *   Array of pages.
+   */
+  public function getPages(): array;
+
+  /**
+   * Add a new page to this import.
+   */
+  public function addPage(PageInterface $page): void;
+
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -5,7 +5,7 @@ namespace Drupal\localgov_publications_importer;
 /**
  * Represents a single page of content being imported.
  */
-class Page {
+class Page implements PageInterface {
 
   /**
    * Title of the page.
@@ -22,28 +22,28 @@ class Page {
   protected string $content = '';
 
   /**
-   * Set the title of the import.
+   * {@inheritdoc}
    */
   public function setTitle(string $title): void {
     $this->title = $title;
   }
 
   /**
-   * Get the title of the import.
+   * {@inheritdoc}
    */
   public function getTitle(): string {
     return $this->title;
   }
 
   /**
-   * Set the content of the page.
+   * {@inheritdoc}
    */
   public function setContent(string $content): void {
     $this->content = $content;
   }
 
   /**
-   * Get the content of the page.
+   * {@inheritdoc}
    */
   public function getContent(): string {
     return $this->content;

--- a/src/Page.php
+++ b/src/Page.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+/**
+ * Represents a single page of content being imported.
+ */
+class Page {
+
+  /**
+   * Title of the page.
+   *
+   * @var string
+   */
+  protected string $title = '';
+
+  /**
+   * Content of the page.
+   *
+   * @var string
+   */
+  protected string $content = '';
+
+  /**
+   * Set the title of the import.
+   */
+  public function setTitle(string $title): void {
+    $this->title = $title;
+  }
+
+  /**
+   * Get the title of the import.
+   */
+  public function getTitle(): string {
+    return $this->title;
+  }
+
+  /**
+   * Set the content of the page.
+   */
+  public function setContent(string $content): void {
+    $this->content = $content;
+  }
+
+  /**
+   * Get the content of the page.
+   */
+  public function getContent(): string {
+    return $this->content;
+  }
+
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -22,6 +22,13 @@ class Page implements PageInterface {
   protected string $content = '';
 
   /**
+   * Page number.
+   *
+   * @var int|null
+   */
+  protected ?int $pageNumber = NULL;
+
+  /**
    * {@inheritdoc}
    */
   public function setTitle(string $title): void {
@@ -47,6 +54,20 @@ class Page implements PageInterface {
    */
   public function getContent(): string {
     return $this->content;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setPageNumber(int $pageNumber): void {
+    $this->pageNumber = $pageNumber;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPageNumber(): ?int {
+    return $this->pageNumber;
   }
 
 }

--- a/src/PageInterface.php
+++ b/src/PageInterface.php
@@ -27,4 +27,14 @@ interface PageInterface {
    */
   public function getContent(): string;
 
+  /**
+   * Set the poge number.
+   */
+  public function setPageNumber(int $pageNumber): void;
+
+  /**
+   * Get the poge number.
+   */
+  public function getPageNumber(): ?int;
+
 }

--- a/src/PageInterface.php
+++ b/src/PageInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+/**
+ * Interface for a single page of content being imported.
+ */
+interface PageInterface {
+
+  /**
+   * Set the title of the page.
+   */
+  public function setTitle(string $title): void;
+
+  /**
+   * Get the title of the page.
+   */
+  public function getTitle(): string;
+
+  /**
+   * Set the content of the page.
+   */
+  public function setContent(string $content): void;
+
+  /**
+   * Get the content of the page.
+   */
+  public function getContent(): string;
+
+}

--- a/src/Plugin/ExtractInterface.php
+++ b/src/Plugin/ExtractInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin;
+
+use Drupal\localgov_publications_importer\Import;
+
+/**
+ * Interface for Extract Operation plugins.
+ *
+ * Accepts a file, and returns an Import object.
+ */
+interface ExtractInterface {
+  // Accepts a file?
+  function setSource(string $pathToFile): self;
+
+  // Returns an import.
+  function getImport(): ?Import;
+}

--- a/src/Plugin/ExtractInterface.php
+++ b/src/Plugin/ExtractInterface.php
@@ -21,7 +21,12 @@ interface ExtractInterface {
    */
   public function setSource(string $pathToFile): self;
 
-  // Returns an import.
+  /**
+   * Creates a new Import object with the extracted content.
+   *
+   * @return ?Import
+   *   The new import.
+   */
   public function getImport(): ?Import;
 
 }

--- a/src/Plugin/ExtractInterface.php
+++ b/src/Plugin/ExtractInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\localgov_publications_importer\Plugin;
 
-use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\ImportInterface;
 
 /**
  * Interface for Extract Operation plugins.
@@ -24,9 +24,9 @@ interface ExtractInterface {
   /**
    * Creates a new Import object with the extracted content.
    *
-   * @return ?Import
+   * @return ?\Drupal\localgov_publications_importer\ImportInterface
    *   The new import.
    */
-  public function getImport(): ?Import;
+  public function getImport(): ?ImportInterface;
 
 }

--- a/src/Plugin/ExtractInterface.php
+++ b/src/Plugin/ExtractInterface.php
@@ -10,9 +10,18 @@ use Drupal\localgov_publications_importer\Import;
  * Accepts a file, and returns an Import object.
  */
 interface ExtractInterface {
-  // Accepts a file?
-  function setSource(string $pathToFile): self;
+
+  /**
+   * Accepts a file.
+   *
+   * @param string $pathToFile
+   *   Path to the file.
+   *
+   * @return $this
+   */
+  public function setSource(string $pathToFile): self;
 
   // Returns an import.
-  function getImport(): ?Import;
+  public function getImport(): ?Import;
+
 }

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -2,13 +2,13 @@
 
 namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Extract;
 
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_publications_importer\Attribute\Extract;
 use Drupal\localgov_publications_importer\Import;
 use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
 use Smalot\PdfParser\Config as PdfParserConfig;
 use Smalot\PdfParser\Parser as PdfParser;
-use Smalot\PdfParser\Document as PdfDocument;
-use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Extract operation that uses Smalot/pdfparser.
@@ -18,17 +18,26 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
   label: new TranslatableMarkup('Smalot extract'),
   description: new TranslatableMarkup('Extract operation that uses Smalot/pdfparser')
 )]
-class SmalotPdfParserExtract implements ExtractInterface {
+class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
 
+  /**
+   * Path to the file to import.
+   *
+   * @var string
+   */
   protected string $pathToFile;
 
-  protected PdfDocument $pdf;
-
+  /**
+   * {@inheritDoc}
+   */
   public function setSource(string $pathToFile): self {
     $this->pathToFile = $pathToFile;
     return $this;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   public function getImport(): ?Import {
 
     $config = new PdfParserConfig();
@@ -37,17 +46,17 @@ class SmalotPdfParserExtract implements ExtractInterface {
 
     // Parse PDF file and build necessary objects.
     $parser = new PdfParser([], $config);
-    $this->pdf = $parser->parseFile($this->pathToFile);
+    $pdf = $parser->parseFile($this->pathToFile);
 
     $import = new Import($this->pathToFile);
 
-    $details = $this->pdf->getDetails();
+    $details = $pdf->getDetails();
     if (isset($details['Title'])) {
       $import->setTitle($details['Title']);
     }
 
     // Get the pages and sort them. They don't come back in order by default.
-    $pages = $this->pdf->getPages();
+    $pages = $pdf->getPages();
     usort($pages, function ($a, $b) {
       return intval($a->getPageNumber()) <=> intval($b->getPageNumber());
     });

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -72,6 +72,7 @@ class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
       $page = new Page();
       $page->setTitle('Page ' . $pdfPage->getPageNumber());
       $page->setContent($pdfPage->getText());
+      $page->setPageNumber($pdfPage->getPageNumber());
       $import->addPage($page);
     }
 

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_publications_importer\Attribute\Extract;
 use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\ImportInterface;
 use Drupal\localgov_publications_importer\Page;
 use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
 use Smalot\PdfParser\Config as PdfParserConfig;
@@ -39,7 +40,7 @@ class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
   /**
    * {@inheritDoc}
    */
-  public function getImport(): ?Import {
+  public function getImport(): ?ImportInterface {
 
     $config = new PdfParserConfig();
     // An empty string can prevent words from breaking up.

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Extract;
+
+use Drupal\localgov_publications_importer\Attribute\Extract;
+use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
+use Smalot\PdfParser\Config as PdfParserConfig;
+use Smalot\PdfParser\Parser as PdfParser;
+use Smalot\PdfParser\Document as PdfDocument;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Extract operation that uses Smalot/pdfparser.
+ */
+#[Extract(
+  id: 'smalot_pdfparser',
+  label: new TranslatableMarkup('Smalot extract'),
+  description: new TranslatableMarkup('Extract operation that uses Smalot/pdfparser')
+)]
+class SmalotPdfParserExtract implements ExtractInterface {
+
+  protected string $pathToFile;
+
+  protected PdfDocument $pdf;
+
+  public function setSource(string $pathToFile): self {
+    $this->pathToFile = $pathToFile;
+    return $this;
+  }
+
+  public function getImport(): ?Import {
+
+    $config = new PdfParserConfig();
+    // An empty string can prevent words from breaking up.
+    $config->setHorizontalOffset('');
+
+    // Parse PDF file and build necessary objects.
+    $parser = new PdfParser([], $config);
+    $this->pdf = $parser->parseFile($this->pathToFile);
+
+    $import = new Import($this->pathToFile);
+
+    $details = $this->pdf->getDetails();
+    if (isset($details['Title'])) {
+      $import->setTitle($details['Title']);
+    }
+
+    // Get the pages and sort them. They don't come back in order by default.
+    $pages = $this->pdf->getPages();
+    usort($pages, function ($a, $b) {
+      return intval($a->getPageNumber()) <=> intval($b->getPageNumber());
+    });
+
+    // @todo: We need our own page representation so the whole project isn't
+    // tied to what smalot/pdfparser does.
+    $import->setPages($pages);
+
+    return $import;
+  }
+
+}

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -52,8 +52,13 @@ class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
     $import = new Import($this->pathToFile);
 
     $details = $pdf->getDetails();
-    if (isset($details['Title'])) {
+    if (isset($details['Title']) && $details['Title'] !== '') {
       $import->setTitle($details['Title']);
+    }
+    else {
+      // Fall back to the filename if we can't find a title in the PDF.
+      // This isn't ideal, but we need to have a title to save a node.
+      $import->setTitle(basename($this->pathToFile));
     }
 
     // Get the pages and sort them. They don't come back in order by default.

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_publications_importer\Attribute\Extract;
 use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\Page;
 use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
 use Smalot\PdfParser\Config as PdfParserConfig;
 use Smalot\PdfParser\Parser as PdfParser;
@@ -56,14 +57,17 @@ class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
     }
 
     // Get the pages and sort them. They don't come back in order by default.
-    $pages = $pdf->getPages();
-    usort($pages, function ($a, $b) {
+    $pdfPages = $pdf->getPages();
+    usort($pdfPages, function ($a, $b) {
       return intval($a->getPageNumber()) <=> intval($b->getPageNumber());
     });
 
-    // @todo Add our own page representation so the whole project isn't tied to
-    // what smalot/pdfparser does.
-    $import->setPages($pages);
+    foreach ($pdfPages as $pdfPage) {
+      $page = new Page();
+      $page->setTitle('Page ' . $pdfPage->getPageNumber());
+      $page->setContent($pdfPage->getText());
+      $import->addPage($page);
+    }
 
     return $import;
   }

--- a/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
+++ b/src/Plugin/LocalGovImporter/Extract/SmalotPdfParserExtract.php
@@ -61,8 +61,8 @@ class SmalotPdfParserExtract extends PluginBase implements ExtractInterface {
       return intval($a->getPageNumber()) <=> intval($b->getPageNumber());
     });
 
-    // @todo: We need our own page representation so the whole project isn't
-    // tied to what smalot/pdfparser does.
+    // @todo Add our own page representation so the whole project isn't tied to
+    // what smalot/pdfparser does.
     $import->setPages($pages);
 
     return $import;

--- a/src/Plugin/LocalGovImporter/Save/Publication.php
+++ b/src/Plugin/LocalGovImporter/Save/Publication.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_publications_importer\Attribute\Save;
-use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\ImportInterface;
 use Drupal\localgov_publications_importer\Plugin\SaveInterface;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
@@ -50,7 +50,7 @@ class Publication extends PluginBase implements SaveInterface, ContainerFactoryP
   /**
    * {@inheritDoc}
    */
-  public function import(Import $import): ?NodeInterface {
+  public function import(ImportInterface $import): ?NodeInterface {
 
     $rootPage = NULL;
     $weight = 0;

--- a/src/Plugin/LocalGovImporter/Save/Publication.php
+++ b/src/Plugin/LocalGovImporter/Save/Publication.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Save;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\localgov_publications_importer\Attribute\Save;
+use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\Plugin\SaveInterface;
+use Drupal\node\NodeInterface;
+use Drupal\paragraphs\Entity\Paragraph;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Save operation to save content as an HTML publication.
+ */
+#[Save(
+  id: 'save_publication',
+  label: new TranslatableMarkup('Publication'),
+  description: new TranslatableMarkup('Save operation that creates an HTML publication.')
+)]
+class Publication extends PluginBase implements SaveInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Creates a Publication Save Operation.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function import(Import $import): ?NodeInterface {
+
+    $rootPage = NULL;
+    $weight = 0;
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+
+    foreach ($import->getPages() as $page) {
+
+      if ($rootPage === NULL) {
+        $book = [
+          'bid' => 'new',
+        ];
+        $title = $import->getTitle();
+      }
+      else {
+        $book = [
+          'bid' => $rootPage->id(),
+          'pid' => $rootPage->id(),
+          'weight' => $weight++,
+        ];
+        $title = 'Page ' . $page->getPageNumber();
+      }
+
+      $publicationPage = $nodeStorage->create([
+        'type' => 'localgov_publication_page',
+        'title' => $title,
+        'book' => $book,
+      ]);
+
+      // Create the paragraph that holds the text. NB that both the paragraph
+      // and the field on it are called 'localgov_text'.
+      $paragraph = Paragraph::create([
+        'type' => 'localgov_text',
+        'localgov_text' => [
+          'value' => $page->getContent(),
+          'format' => 'wysiwyg',
+        ],
+      ]);
+      $paragraph->save();
+
+      $paragraphList[] = [
+        'target_id' => $paragraph->id(),
+        'target_revision_id' => $paragraph->getRevisionId(),
+      ];
+
+      $publicationPage->get('localgov_publication_content')->setValue($paragraphList);
+
+      $publicationPage->save();
+
+      if ($rootPage === NULL) {
+        $rootPage = $publicationPage;
+      }
+    }
+
+    return $rootPage;
+  }
+
+}

--- a/src/Plugin/LocalGovImporter/Transform/AI.php
+++ b/src/Plugin/LocalGovImporter/Transform/AI.php
@@ -12,14 +12,14 @@ use Drupal\localgov_publications_importer\PageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Transform operation to Transform content as an HTML publication.
+ * Transform operation that uses AI to clean up content.
  */
 #[Transform(
-  id: 'transform_chatgpt',
-  label: new TranslatableMarkup('ChatGPT'),
-  description: new TranslatableMarkup('Uses ChatGPT to reintroduce missing document structure.')
+  id: 'transform_ai',
+  label: new TranslatableMarkup('AI'),
+  description: new TranslatableMarkup('Uses AI to reintroduce missing document structure.')
 )]
-class ChatGPT extends TransformPluginBase implements ContainerFactoryPluginInterface {
+class AI extends TransformPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/LocalGovImporter/Transform/Ai.php
+++ b/src/Plugin/LocalGovImporter/Transform/Ai.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
   label: new TranslatableMarkup('AI'),
   description: new TranslatableMarkup('Uses AI to reintroduce missing document structure.')
 )]
-class AI extends TransformPluginBase implements ContainerFactoryPluginInterface {
+class Ai extends TransformPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
+++ b/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
@@ -52,6 +52,13 @@ class ChatGPT extends TransformPluginBase implements ContainerFactoryPluginInter
 
     $sets = $this->aiProvider->getDefaultProviderForOperationType('chat');
 
+    // If there's no AI provider returned, don't try to use one.
+    // @todo Consider better ways to handle this.
+    // Log an error? Show a flash message?
+    if (is_null($sets)) {
+      return;
+    }
+
     $provider = $this->aiProvider->createInstance($sets['provider_id']);
     $messages = new ChatInput([
       new chatMessage('system', 'This plain text document has been stripped of its formatting. Please add the formatting back in, and give me the whole document back as valid HTML.'),

--- a/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
+++ b/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
@@ -8,7 +8,7 @@ use Drupal\ai\OperationType\Chat\ChatMessage;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\localgov_publications_importer\Attribute\Transform;
-use Drupal\localgov_publications_importer\Page;
+use Drupal\localgov_publications_importer\PageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -48,7 +48,7 @@ class ChatGPT extends TransformPluginBase implements ContainerFactoryPluginInter
   /**
    * {@inheritDoc}
    */
-  public function transformPage(Page $page): void {
+  public function transformPage(PageInterface $page): void {
 
     $sets = $this->aiProvider->getDefaultProviderForOperationType('chat');
 

--- a/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
+++ b/src/Plugin/LocalGovImporter/Transform/ChatGPT.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform;
+
+use Drupal\ai\AiProviderPluginManager;
+use Drupal\ai\OperationType\Chat\ChatInput;
+use Drupal\ai\OperationType\Chat\ChatMessage;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\localgov_publications_importer\Attribute\Transform;
+use Drupal\localgov_publications_importer\Page;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Transform operation to Transform content as an HTML publication.
+ */
+#[Transform(
+  id: 'transform_chatgpt',
+  label: new TranslatableMarkup('ChatGPT'),
+  description: new TranslatableMarkup('Uses ChatGPT to reintroduce missing document structure.')
+)]
+class ChatGPT extends TransformPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('ai.provider')
+    );
+  }
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected AiProviderPluginManager $aiProvider,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transformPage(Page $page): void {
+
+    $sets = $this->aiProvider->getDefaultProviderForOperationType('chat');
+
+    $provider = $this->aiProvider->createInstance($sets['provider_id']);
+    $messages = new ChatInput([
+      new chatMessage('system', 'This plain text document has been stripped of its formatting. Please add the formatting back in, and give me the whole document back as valid HTML.'),
+      new chatMessage('user', $page->getContent()),
+    ]);
+    $message = $provider->chat($messages, $sets['model_id'])->getNormalized();
+    $page->setContent($message->getText());
+  }
+
+}

--- a/src/Plugin/LocalGovImporter/Transform/Linebreaks.php
+++ b/src/Plugin/LocalGovImporter/Transform/Linebreaks.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\localgov_publications_importer\Attribute\Transform;
+
+/**
+ * Transform operation to fix line breaks.
+ */
+#[Transform(
+  id: 'transform_line_breaks',
+  label: new TranslatableMarkup('Line breaks'),
+  description: new TranslatableMarkup('Remove rogue line breaks and other whitespace from content.')
+)]
+class Linebreaks extends TransformPluginBase {
+
+  /**
+   * Replace unwanted whitespace in the content with a space.
+   */
+  public function transformContent(string $content): string {
+    return str_replace("\t\n", ' ', $content);
+  }
+
+}

--- a/src/Plugin/LocalGovImporter/Transform/TransformPluginBase.php
+++ b/src/Plugin/LocalGovImporter/Transform/TransformPluginBase.php
@@ -3,8 +3,8 @@
 namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform;
 
 use Drupal\Component\Plugin\PluginBase;
-use Drupal\localgov_publications_importer\Import;
-use Drupal\localgov_publications_importer\Page;
+use Drupal\localgov_publications_importer\ImportInterface;
+use Drupal\localgov_publications_importer\PageInterface;
 use Drupal\localgov_publications_importer\Plugin\TransformInterface;
 
 /**
@@ -19,7 +19,7 @@ abstract class TransformPluginBase extends PluginBase implements TransformInterf
   /**
    * {@inheritDoc}
    */
-  public function transform(Import $import): void {
+  public function transform(ImportInterface $import): void {
 
     foreach ($import->getPages() as $page) {
       $this->transformPage($page);
@@ -31,7 +31,7 @@ abstract class TransformPluginBase extends PluginBase implements TransformInterf
    *
    * If you just want to act on a single page, implement this in your plugin.
    */
-  protected function transformPage(Page $page): void {
+  protected function transformPage(PageInterface $page): void {
     $page->setContent($this->transformContent($page->getContent()));
   }
 

--- a/src/Plugin/LocalGovImporter/Transform/TransformPluginBase.php
+++ b/src/Plugin/LocalGovImporter/Transform/TransformPluginBase.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\Page;
+use Drupal\localgov_publications_importer\Plugin\TransformInterface;
+
+/**
+ * Base transform plugin.
+ *
+ * This lets transform plugin authors implement
+ * transformPage() or transformContent() instead of transform() if they want
+ * their code to act on a single page's content.
+ */
+abstract class TransformPluginBase extends PluginBase implements TransformInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform(Import $import): void {
+
+    foreach ($import->getPages() as $page) {
+      $this->transformPage($page);
+    }
+  }
+
+  /**
+   * Transforms a single page.
+   *
+   * If you just want to act on a single page, implement this in your plugin.
+   */
+  protected function transformPage(Page $page): void {
+    $page->setContent($this->transformContent($page->getContent()));
+  }
+
+  /**
+   * Transforms the content of a single page.
+   *
+   * If you just want to alter content, implement this in your plugin.
+   */
+  protected function transformContent(string $content): string {
+    return $content;
+  }
+
+}

--- a/src/Plugin/SaveInterface.php
+++ b/src/Plugin/SaveInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin;
+
+use Drupal\localgov_publications_importer\Import;
+use Drupal\node\NodeInterface;
+
+/**
+ * Interface for Save Operation plugins.
+ *
+ * Accepts an import object and saves it to the database.
+ */
+interface SaveInterface {
+
+  /**
+   * Import the content.
+   *
+   * Returns a Node on success, null otherwise.
+   */
+  public function import(Import $import): ?NodeInterface;
+}

--- a/src/Plugin/SaveInterface.php
+++ b/src/Plugin/SaveInterface.php
@@ -18,4 +18,5 @@ interface SaveInterface {
    * Returns a Node on success, null otherwise.
    */
   public function import(Import $import): ?NodeInterface;
+
 }

--- a/src/Plugin/SaveInterface.php
+++ b/src/Plugin/SaveInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\localgov_publications_importer\Plugin;
 
-use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\ImportInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -17,6 +17,6 @@ interface SaveInterface {
    *
    * Returns a Node on success, null otherwise.
    */
-  public function import(Import $import): ?NodeInterface;
+  public function import(ImportInterface $import): ?NodeInterface;
 
 }

--- a/src/Plugin/TransformInterface.php
+++ b/src/Plugin/TransformInterface.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\localgov_publications_importer\Plugin;
 
-use Drupal\localgov_publications_importer\Import;
+use Drupal\localgov_publications_importer\ImportInterface;
 
 /**
  * Interface for Transform Operation plugins.
@@ -14,6 +14,6 @@ interface TransformInterface {
   /**
    * Transform the content.
    */
-  public function transform(Import $import): void;
+  public function transform(ImportInterface $import): void;
 
 }

--- a/src/Plugin/TransformInterface.php
+++ b/src/Plugin/TransformInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\localgov_publications_importer\Plugin;
+
+use Drupal\localgov_publications_importer\Import;
+
+/**
+ * Interface for Transform Operation plugins.
+ *
+ * Accepts an import object and transforms it.
+ */
+interface TransformInterface {
+
+  /**
+   * Transform the content.
+   */
+  public function transform(Import $import): void;
+
+}

--- a/src/SaveOperationManager.php
+++ b/src/SaveOperationManager.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\localgov_publications_importer\Attribute\Save;
+use Drupal\localgov_publications_importer\Plugin\SaveInterface;
+
+/**
+ * Manages discovery and instantiation of Save operations.
+ */
+class SaveOperationManager extends DefaultPluginManager {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/LocalGovImporter/Save',
+      $namespaces,
+      $module_handler,
+      SaveInterface::class,
+      Save::class
+    );
+
+    $this->alterInfo('localgov_importer_save_operation_info');
+    $this->setCacheBackend($cache_backend, 'localgov_importer_save_operations');
+  }
+
+}

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -2,13 +2,11 @@
 
 namespace Drupal\localgov_publications_importer\Service;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\localgov_publications_importer\ExtractOperationManager;
 use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
+use Drupal\localgov_publications_importer\Plugin\SaveInterface;
+use Drupal\localgov_publications_importer\SaveOperationManager;
 use Drupal\node\NodeInterface;
-use Drupal\paragraphs\Entity\Paragraph;
-use Smalot\PdfParser\Config as PdfParserConfig;
-use Smalot\PdfParser\Parser as PdfParser;
 use Drupal\ai\OperationType\Chat\ChatInput;
 use Drupal\ai\OperationType\Chat\ChatMessage;
 use Drupal\ai\AiProviderPluginManager;
@@ -22,9 +20,9 @@ class Importer {
    * Constructor.
    */
   public function __construct(
-    protected EntityTypeManagerInterface $entityTypeManager,
     protected AiProviderPluginManager $aiProvider,
     protected ExtractOperationManager $extractOperationManager,
+    protected SaveOperationManager $saveOperationManager,
   ) {
   }
 
@@ -37,33 +35,9 @@ class Importer {
       ->setSource($pathToFile)
       ->getImport();
 
-    $rootPage = NULL;
-    $weight = 0;
-
-    $nodeStorage = $this->entityTypeManager->getStorage('node');
-
+    // @todoL: Everything left in this loop should be a transform plugin.
     foreach ($import->getPages() as $page) {
 
-      if ($rootPage === NULL) {
-        $book = [
-          'bid' => 'new',
-        ];
-        $title = $import->getTitle();
-      }
-      else {
-        $book = [
-          'bid' => $rootPage->id(),
-          'pid' => $rootPage->id(),
-          'weight' => $weight++,
-        ];
-        $title = 'Page ' . $page->getPageNumber();
-      }
-
-      $publicationPage = $nodeStorage->create([
-        'type' => 'localgov_publication_page',
-        'title' => $title,
-        'book' => $book,
-      ]);
 
       // One of the example PDFs I tried came out wth \t\n after every single
       // word, which rendered as line breaks and made the output a single column
@@ -80,43 +54,14 @@ class Importer {
       ]);
       $message = $provider->chat($messages, $sets['model_id'])->getNormalized();
       $content = $message->getText();
-
-      $this->addBodyAsParagraph($publicationPage, $content);
-
-      $publicationPage->save();
-
-      if ($rootPage === NULL) {
-        $rootPage = $publicationPage;
-      }
     }
 
-    return $rootPage;
+    return $this->saveOperation()->import($import);
   }
 
   /**
-   * Add content to the given node as a paragraph.
+   * Gets the extract operation to use.
    */
-  public function addBodyAsParagraph(NodeInterface $node, string $text): void {
-
-    // Create the paragraph that holds the text. NB that both the paragraph
-    // and the field on it are called 'localgov_text'.
-    $paragraph = Paragraph::create([
-      'type' => 'localgov_text',
-      'localgov_text' => [
-        'value' => $text,
-        'format' => 'wysiwyg',
-      ],
-    ]);
-    $paragraph->save();
-
-    $paragraphList[] = [
-      'target_id' => $paragraph->id(),
-      'target_revision_id' => $paragraph->getRevisionId(),
-    ];
-
-    $node->get('localgov_publication_content')->setValue($paragraphList);
-  }
-
   protected function extractOperation(): ExtractInterface {
     $extractOperationDefinitions = $this->extractOperationManager->getDefinitions();
 
@@ -128,6 +73,22 @@ class Importer {
     $extractOperation = $this->extractOperationManager->createInstance($extractOperationDefinition['id']);
 
     return $extractOperation;
+  }
+
+  /**
+   * Gets the save operation to use.
+   */
+  protected function saveOperation(): SaveInterface {
+    $saveOperationDefinitions = $this->saveOperationManager->getDefinitions();
+
+    // @todo: There should only be one save operation in this pipeline.
+    // Provide a way to choose it, and the other operations!
+    $saveOperationDefinition = reset($saveOperationDefinitions);
+
+    /** @var \Drupal\localgov_publications_importer\Plugin\SaveInterface $saveOperation */
+    $saveOperation = $this->extractOperationManager->createInstance($saveOperationDefinition['id']);
+
+    return $saveOperation;
   }
 
 }

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -35,9 +35,8 @@ class Importer {
       ->setSource($pathToFile)
       ->getImport();
 
-    // @todoL: Everything left in this loop should be a transform plugin.
+    // @todo Everything left in this loop should be a transform plugin.
     foreach ($import->getPages() as $page) {
-
 
       // One of the example PDFs I tried came out wth \t\n after every single
       // word, which rendered as line breaks and made the output a single column
@@ -65,7 +64,7 @@ class Importer {
   protected function extractOperation(): ExtractInterface {
     $extractOperationDefinitions = $this->extractOperationManager->getDefinitions();
 
-    // @todo: There should only be one extract operation in this pipeline.
+    // @todo There should only be one extract operation in this pipeline.
     // Provide a way to choose it, and the other operations!
     $extractOperationDefinition = reset($extractOperationDefinitions);
 
@@ -81,7 +80,7 @@ class Importer {
   protected function saveOperation(): SaveInterface {
     $saveOperationDefinitions = $this->saveOperationManager->getDefinitions();
 
-    // @todo: There should only be one save operation in this pipeline.
+    // @todo There should only be one save operation in this pipeline.
     // Provide a way to choose it, and the other operations!
     $saveOperationDefinition = reset($saveOperationDefinitions);
 

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -3,6 +3,8 @@
 namespace Drupal\localgov_publications_importer\Service;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\localgov_publications_importer\ExtractOperationManager;
+use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Smalot\PdfParser\Config as PdfParserConfig;
@@ -22,6 +24,7 @@ class Importer {
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AiProviderPluginManager $aiProvider,
+    protected ExtractOperationManager $extractOperationManager,
   ) {
   }
 
@@ -30,40 +33,22 @@ class Importer {
    */
   public function importPdf($pathToFile): ?NodeInterface {
 
-    $nodeStorage = $this->entityTypeManager->getStorage('node');
-
-    $config = new PdfParserConfig();
-    // An empty string can prevent words from breaking up.
-    $config->setHorizontalOffset('');
-
-    // Parse PDF file and build necessary objects.
-    $parser = new PdfParser([], $config);
-    $pdf = $parser->parseFile($pathToFile);
-
-    $title = 'Publication';
-
-    $details = $pdf->getDetails();
-
-    if (isset($details['Title'])) {
-      $title = $details['Title'];
-    }
+    $import = $this->extractOperation()
+      ->setSource($pathToFile)
+      ->getImport();
 
     $rootPage = NULL;
-
-    // Get the pages and sort them. They don't come back in order by default.
-    $pages = $pdf->getPages();
-    usort($pages, function ($a, $b) {
-      return intval($a->getPageNumber()) <=> intval($b->getPageNumber());
-    });
-
     $weight = 0;
 
-    foreach ($pages as $page) {
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+
+    foreach ($import->getPages() as $page) {
 
       if ($rootPage === NULL) {
         $book = [
           'bid' => 'new',
         ];
+        $title = $import->getTitle();
       }
       else {
         $book = [
@@ -130,6 +115,19 @@ class Importer {
     ];
 
     $node->get('localgov_publication_content')->setValue($paragraphList);
+  }
+
+  protected function extractOperation(): ExtractInterface {
+    $extractOperationDefinitions = $this->extractOperationManager->getDefinitions();
+
+    // @todo: There should only be one extract operation in this pipeline.
+    // Provide a way to choose it, and the other operations!
+    $extractOperationDefinition = reset($extractOperationDefinitions);
+
+    /** @var \Drupal\localgov_publications_importer\Plugin\ExtractInterface $extractOperation */
+    $extractOperation = $this->extractOperationManager->createInstance($extractOperationDefinition['id']);
+
+    return $extractOperation;
   }
 
 }

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -81,7 +81,7 @@ class Importer {
     $operationDefinition = reset($operationDefinitions);
 
     /** @var \Drupal\localgov_publications_importer\Plugin\SaveInterface $operation */
-    $operation = $this->extractOperationManager->createInstance($operationDefinition['id']);
+    $operation = $this->saveOperationManager->createInstance($operationDefinition['id']);
 
     return $operation;
   }

--- a/src/Service/Importer.php
+++ b/src/Service/Importer.php
@@ -6,10 +6,8 @@ use Drupal\localgov_publications_importer\ExtractOperationManager;
 use Drupal\localgov_publications_importer\Plugin\ExtractInterface;
 use Drupal\localgov_publications_importer\Plugin\SaveInterface;
 use Drupal\localgov_publications_importer\SaveOperationManager;
+use Drupal\localgov_publications_importer\TransformOperationManager;
 use Drupal\node\NodeInterface;
-use Drupal\ai\OperationType\Chat\ChatInput;
-use Drupal\ai\OperationType\Chat\ChatMessage;
-use Drupal\ai\AiProviderPluginManager;
 
 /**
  * Imports content from uploaded files.
@@ -20,14 +18,14 @@ class Importer {
    * Constructor.
    */
   public function __construct(
-    protected AiProviderPluginManager $aiProvider,
     protected ExtractOperationManager $extractOperationManager,
+    protected TransformOperationManager $transformOperationManager,
     protected SaveOperationManager $saveOperationManager,
   ) {
   }
 
   /**
-   * Imports the given file as a new Localgov Publication page.
+   * Imports the given file as a new LocalGov Publication page.
    */
   public function importPdf($pathToFile): ?NodeInterface {
 
@@ -35,24 +33,8 @@ class Importer {
       ->setSource($pathToFile)
       ->getImport();
 
-    // @todo Everything left in this loop should be a transform plugin.
-    foreach ($import->getPages() as $page) {
-
-      // One of the example PDFs I tried came out wth \t\n after every single
-      // word, which rendered as line breaks and made the output a single column
-      // of words. Swop these for spaces.
-      $content = str_replace("\t\n", ' ', $page->getText());
-
-      // Find the default selected LLM:
-      $sets = $this->aiProvider->getDefaultProviderForOperationType('chat');
-
-      $provider = $this->aiProvider->createInstance($sets['provider_id']);
-      $messages = new ChatInput([
-        new chatMessage('system', 'This plain text document has been stripped of its formatting. Please add the formatting back in, and give me the whole document back as valid HTML.'),
-        new chatMessage('user', $content),
-      ]);
-      $message = $provider->chat($messages, $sets['model_id'])->getNormalized();
-      $content = $message->getText();
+    foreach ($this->transformOperations() as $transformOperation) {
+      $transformOperation->transform($import);
     }
 
     return $this->saveOperation()->import($import);
@@ -62,32 +44,46 @@ class Importer {
    * Gets the extract operation to use.
    */
   protected function extractOperation(): ExtractInterface {
-    $extractOperationDefinitions = $this->extractOperationManager->getDefinitions();
+    $operationDefinitions = $this->extractOperationManager->getDefinitions();
 
     // @todo There should only be one extract operation in this pipeline.
     // Provide a way to choose it, and the other operations!
-    $extractOperationDefinition = reset($extractOperationDefinitions);
+    $operationDefinition = reset($operationDefinitions);
 
-    /** @var \Drupal\localgov_publications_importer\Plugin\ExtractInterface $extractOperation */
-    $extractOperation = $this->extractOperationManager->createInstance($extractOperationDefinition['id']);
+    /** @var \Drupal\localgov_publications_importer\Plugin\ExtractInterface $operation */
+    $operation = $this->extractOperationManager->createInstance($operationDefinition['id']);
 
-    return $extractOperation;
+    return $operation;
+  }
+
+  /**
+   * Gets the transform operations to use.
+   *
+   * @return \Drupal\localgov_publications_importer\Plugin\TransformInterface[]
+   *   Array of transform operations.
+   */
+  protected function transformOperations(): array {
+    $operations = [];
+    foreach ($this->transformOperationManager->getDefinitions() as $operationDefinition) {
+      $operations[] = $this->transformOperationManager->createInstance($operationDefinition['id']);
+    }
+    return $operations;
   }
 
   /**
    * Gets the save operation to use.
    */
   protected function saveOperation(): SaveInterface {
-    $saveOperationDefinitions = $this->saveOperationManager->getDefinitions();
+    $operationDefinitions = $this->saveOperationManager->getDefinitions();
 
     // @todo There should only be one save operation in this pipeline.
     // Provide a way to choose it, and the other operations!
-    $saveOperationDefinition = reset($saveOperationDefinitions);
+    $operationDefinition = reset($operationDefinitions);
 
-    /** @var \Drupal\localgov_publications_importer\Plugin\SaveInterface $saveOperation */
-    $saveOperation = $this->extractOperationManager->createInstance($saveOperationDefinition['id']);
+    /** @var \Drupal\localgov_publications_importer\Plugin\SaveInterface $operation */
+    $operation = $this->extractOperationManager->createInstance($operationDefinition['id']);
 
-    return $saveOperation;
+    return $operation;
   }
 
 }

--- a/src/TransformOperationManager.php
+++ b/src/TransformOperationManager.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\localgov_publications_importer;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\localgov_publications_importer\Attribute\Transform;
+use Drupal\localgov_publications_importer\Plugin\TransformInterface;
+
+/**
+ * Manages discovery and instantiation of Transform operations.
+ */
+class TransformOperationManager extends DefaultPluginManager {
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/LocalGovImporter/Transform',
+      $namespaces,
+      $module_handler,
+      TransformInterface::class,
+      Transform::class
+    );
+
+    $this->alterInfo('localgov_importer_transform_operation_info');
+    $this->setCacheBackend($cache_backend, 'localgov_importer_transform_operations');
+  }
+
+}


### PR DESCRIPTION
I've split up the import process in Drupal\localgov_publications_importer\Service\Importer::importPdf() into three plugin types: Extract, Transform, Save.

You need to have one Extract plugin and one Save plugin. I've moved the existing extract and save code to plugins. (\Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Extract\SmalotPdfParserExtract and \Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Save\Publication).

You can have any number of Transform plugins. I've moved the existing code that fixes whitespace issues and the existing code that calls ChatGPT to plugins. (\Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform\Linebreaks and \Drupal\localgov_publications_importer\Plugin\LocalGovImporter\Transform\ChatGPT)

We need some way of choosing which plugins you'd like to run, and maybe the order that the transform plugins run, but I think there's enough here to consider merging.

Implements #5 