### PR TITLE
Implement install and uninstall hooks for module

### DIFF
--- a/localgov_publications_importer.install
+++ b/localgov_publications_importer.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the LocalGov Publications Importer module.
+ * Install and uninstall functions.
  */
 
 use Drupal\Core\File\FileSystemInterface;

--- a/localgov_publications_importer.install
+++ b/localgov_publications_importer.install
@@ -10,7 +10,7 @@ use Drupal\Core\File\FileSystemInterface;
 /**
  * Implements hook_install().
  */
-function localgov_publications_importer_install() {
+function localgov_publications_importer_install(): void {
   $directory = 'public://localgov_publications_importer';
   $file_system = \Drupal::service('file_system');
   $logger = \Drupal::logger('localgov_publications_importer');
@@ -39,7 +39,7 @@ function localgov_publications_importer_install() {
 /**
  * Implements hook_uninstall().
  */
-function localgov_publications_importer_uninstall() {
+function localgov_publications_importer_uninstall(): void {
   $directory = 'public://localgov_publications_importer';
   $file_system = \Drupal::service('file_system');
   $logger = \Drupal::logger('localgov_publications_importer');

--- a/localgov_publications_importer.install
+++ b/localgov_publications_importer.install
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the LocalGov Publications Importer module.
+ */
+
+use Drupal\Core\File\FileSystemInterface;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_publications_importer_install() {
+  $directory = 'public://localgov_publications_importer';
+  $file_system = \Drupal::service('file_system');
+  $logger = \Drupal::logger('localgov_publications_importer');
+
+  try {
+    if (!file_exists($directory)) {
+      $result = $file_system->prepareDirectory(
+        $directory,
+        FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS
+      );
+
+      if (!$result) {
+        $logger->warning('Failed to create directory %directory during module installation.', ['%directory' => $directory]);
+      }
+    }
+    // No success log for existing or created directory.
+  }
+  catch (\Exception $e) {
+    $logger->error('Error creating directory %directory: @message', [
+      '%directory' => $directory,
+      '@message' => $e->getMessage(),
+    ]);
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function localgov_publications_importer_uninstall() {
+  $directory = 'public://localgov_publications_importer';
+  $file_system = \Drupal::service('file_system');
+  $logger = \Drupal::logger('localgov_publications_importer');
+
+  try {
+    if (file_exists($directory)) {
+      $file_system->deleteRecursive($directory);
+      // No success log for removal.
+    }
+    // No log if directory does not exist.
+  }
+  catch (\Exception $e) {
+    $logger->error('Error removing directory %directory: @message', [
+      '%directory' => $directory,
+      '@message' => $e->getMessage(),
+    ]);
+  }
+}


### PR DESCRIPTION
Creates directory public://localgov_publications_importer when module is installed.  Deletes public://localgov_publications_importer when module is uninstalled.



## What does this change?

This change ensures that the module automatically creates the required directory public://localgov_publications_importer during installation and removes it during uninstallation.
Previously, this directory had to be created manually, which could lead to errors if forgotten. Automating this step improves reliability and reduces setup friction.
How it works:
Implements hook_install() to create the directory using Drupal’s file_system service.
Implements hook_uninstall() to remove the directory recursively.

## How to test

On main:
Install the module.
Observe that public://localgov_publications_importer does not exist unless manually created.


On this branch:
Install the module.
Confirm that public://localgov_publications_importer is automatically created.
Uninstall the module.
Confirm that the directory is removed.

## How can we measure success?

No manual steps required for directory creation.
No errors related to missing directory during module usage.
Clean uninstall without leaving orphaned directories.

## Have we considered potential risks?

Risk: Directory deletion on uninstall could remove files if they were manually added by a site admin

