### PR TITLE
Updates Standard import Pipeline

### DIFF
--- a/config/install/localgov_publications_importer.import_pipeline.standard.yml
+++ b/config/install/localgov_publications_importer.import_pipeline.standard.yml
@@ -7,11 +7,8 @@ extract_plugin_configuration: {  }
 transform_plugins:
   - transform_images
   - transform_line_breaks
-  - transform_ai_aio
 transform_plugin_configurations:
   - {  }
   - {  }
-  -
-    prompt: "You are a website content editor. Format the provided text and HTML into valid JSON only.\r\n\r\nRequirements:\r\n- Return ONLY a JSON array of page objects, no other text\r\n- Each page object has: \"title\" (string), \"content\" (string)\r\n- Split the content into MULTIPLE pages\r\n- Each page should contain 200-500 words of content when possible\r\n- Break pages at natural stopping points: section boundaries, topic changes, or major headings\r\n- Content value contains HTML using only the tags: h1, h2, h3, h4, h5, h6, p, ul, ol, li, img\r\n- Use the first line as h1 if it's a complete sentence\r\n- Preserve original text and HTML tags exactly, only add HTML tags\r\n- Generate descriptive titles that reflect each page's main topic\r\n- Pay special attention to img tags - they must be preserved with all original attributes\r\n- Properly escape all double quotes in JSON strings\r\n- Ensure any JSON you create is valid. This is really important.\r\n\r\nSplit strategy:\r\n- Look for major headings, topic shifts, or natural content breaks\r\n- Each page should feel complete but part of a larger whole\r\n- Distribute content evenly across pages\r\n- Don't create pages that are too short (under 100 words) unless necessary\r\n\r\nExample format:\r\n[\r\n  {\"title\":\"Introduction and Overview\",\"content\":\"<h1>Main Title</h1><img src=\"/example-image.jpg\"><p>Intro content...</p>\"},\r\n  {\"title\":\"Key Concepts\",\"content\":\"<h2>Section Title</h2><p>More content...</p>\"},\r\n  {\"title\":\"Advanced Topics\",\"content\":\"<h2>Another Section</h2><p>Final content...</p>\"}\r\n]\r\n"
 save_plugin: save_publication
 save_plugin_configuration: {  }

--- a/modules/localgov_publications_importer_ai/config/install/localgov_publications_importer.import_pipeline.standard_with_ai.yml
+++ b/modules/localgov_publications_importer_ai/config/install/localgov_publications_importer.import_pipeline.standard_with_ai.yml
@@ -1,0 +1,17 @@
+status: true
+dependencies: {  }
+id: standard_with_ai
+label: Standard with AI
+extract_plugin: smalot_pdfparser
+extract_plugin_configuration: {  }
+transform_plugins:
+  - transform_images
+  - transform_line_breaks
+  - transform_ai_aio
+transform_plugin_configurations:
+  - {  }
+  - {  }
+  -
+    prompt: "You are a website content editor. Format the provided text and HTML into valid JSON only.\r\n\r\nRequirements:\r\n- Return ONLY a JSON array of page objects, no other text\r\n- Each page object has: \"title\" (string), \"content\" (string)\r\n- Split the content into MULTIPLE pages\r\n- Each page should contain 200-500 words of content when possible\r\n- Break pages at natural stopping points: section boundaries, topic changes, or major headings\r\n- Content value contains HTML using only the tags: h1, h2, h3, h4, h5, h6, p, ul, ol, li, img\r\n- Use the first line as h1 if it's a complete sentence\r\n- Preserve original text and HTML tags exactly, only add HTML tags\r\n- Generate descriptive titles that reflect each page's main topic\r\n- Pay special attention to img tags - they must be preserved with all original attributes\r\n- Properly escape all double quotes in JSON strings\r\n- Ensure any JSON you create is valid. This is really important.\r\n\r\nSplit strategy:\r\n- Look for major headings, topic shifts, or natural content breaks\r\n- Each page should feel complete but part of a larger whole\r\n- Distribute content evenly across pages\r\n- Don't create pages that are too short (under 100 words) unless necessary\r\n\r\nExample format:\r\n[\r\n  {\"title\":\"Introduction and Overview\",\"content\":\"<h1>Main Title</h1><img src=\"/example-image.jpg\"><p>Intro content...</p>\"},\r\n  {\"title\":\"Key Concepts\",\"content\":\"<h2>Section Title</h2><p>More content...</p>\"},\r\n  {\"title\":\"Advanced Topics\",\"content\":\"<h2>Another Section</h2><p>Final content...</p>\"}\r\n]\r\n"
+save_plugin: save_publication
+save_plugin_configuration: {  }


### PR DESCRIPTION
 Added new Standard with AI pipeline to include it again

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This removes the AI transform_ai_aio transform plugin from the Standard import pipeline, allowing the import process to run without the need for the Localgov Publications Importer AI submodule to be installed. 

Added a new import pipeline called 'Standard with AI' that's created when the submodule is installed. 


## How to test

On main: 

- install localgov_publications_importer
- Navigate to admin/config/system/import-pipeline.
- 'AI all in one.' tranform plugin is selected and configured. 

On this branch: 
- install localgov_publications_importer
- Navigate to admin/config/system/import-pipeline.
- 'AI all in one.' tranform plugin is not selected.
- install localgov_publications_importer_ai
-  Navigate to admin/config/system/import-pipeline
- 'Standard with AI' pipeline has been created. 

## How can we measure success?

Import process can be run (drush plii) without error when localgov_publications_importer_ai is not installed.
When localgov_publications_importer_ai is installed drush plii can be run using the 'Standard with AI' plugin

## Have we considered potential risks?
